### PR TITLE
Add Omnigraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ This repository provides a comprehensive collection of research papers, benchmar
 - [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/getzep/graphiti) Graphiti: A framework for building and querying temporally-aware knowledge graphs, specifically tailored for AI agents operating in dynamic environments
 - [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/memvid/memvid) Memvid: A single-file memory layer for AI agents with instant retrieval and long-term memory
 - [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/ldclabs/anda-hippocampus) Anda Hippocampus: A native graph-based memory system for autonomous AI agents, featuring bio-inspired sleep-based memory consolidation and powered by KIP & AndaDB
+- [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/ModernRelay/omnigraph) Omnigraph: A typed graph database for agent memory with Git-like branch/merge, S3-native storage, and traversal + vector + BM25 search in one Rust runtime
 
 ## 📃 Citation
 

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ This repository provides a comprehensive collection of research papers, benchmar
 - [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/getzep/graphiti) Graphiti: A framework for building and querying temporally-aware knowledge graphs, specifically tailored for AI agents operating in dynamic environments
 - [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/memvid/memvid) Memvid: A single-file memory layer for AI agents with instant retrieval and long-term memory
 - [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/ldclabs/anda-hippocampus) Anda Hippocampus: A native graph-based memory system for autonomous AI agents, featuring bio-inspired sleep-based memory consolidation and powered by KIP & AndaDB
-- [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/ModernRelay/omnigraph) Omnigraph: A typed graph database for agent memory with Git-like branch/merge, S3-native storage, and traversal + vector + BM25 search in one Rust runtime
+- [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/ModernRelay/omnigraph) Omnigraph: Typed graph database for agent memory. S3-native, Rust, traversal + vector + BM25 in one runtime, Git-style branch/merge.
 
 ## 📃 Citation
 


### PR DESCRIPTION
Omnigraph is an open-source typed graph database built for agent memory.

- Git-like branch/merge workflows for memory versioning
- S3-native storage (Rust)
- Traversal + vector + BM25 search in one runtime

https://github.com/ModernRelay/omnigraph