### PR TITLE
Add taOSmd (local-first, benchmarked agent memory on a full transcript)

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ This repository provides a comprehensive collection of research papers, benchmar
 - [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/memvid/memvid) Memvid: A single-file memory layer for AI agents with instant retrieval and long-term memory
 - [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/ldclabs/anda-hippocampus) Anda Hippocampus: A native graph-based memory system for autonomous AI agents, featuring bio-inspired sleep-based memory consolidation and powered by KIP & AndaDB
 - [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/ModernRelay/omnigraph) Omnigraph: Typed graph database for agent memory. S3-native, Rust, traversal + vector + BM25 in one runtime, Git-style branch/merge.
+- [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/jaylfc/taosmd) taOSmd: Local-first, benchmarked agent memory on an append-only transcript, with a typed temporal knowledge graph where corrected facts supersede old ones via invalidation, plus hybrid vector + BM25 retrieval, tuned for small local models
 
 ## 📃 Citation
 


### PR DESCRIPTION
Adds **taOSmd** (https://github.com/jaylfc/taosmd), a local-first, offline agent memory system, to the list, following the existing entry format in this section.

What it is: an append-only, read-only transcript (user + agent messages, tool calls and results, decisions, errors) that a librarian derives a typed temporal knowledge graph and vector memory from. Corrected facts supersede old ones via invalidation (recall returns only the active fact). Hybrid vector + BM25 retrieval, tuned to run on small local models, fully offline (8GB RAM, no API keys). Benchmarked: 97.0% end-to-end Judge on LongMemEval-S and a same-tier leader result on LoCoMo (methodology in docs/benchmarks.md).

Open source (Python API + CLI today; MCP and a local HTTP API are work in progress). Happy to adjust placement, wording, or fields to match your conventions.