### PR TITLE
Add Vestige to Open-source Project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ This repository provides a comprehensive collection of research papers, benchmar
 - [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/ldclabs/anda-hippocampus) Anda Hippocampus: A native graph-based memory system for autonomous AI agents, featuring bio-inspired sleep-based memory consolidation and powered by KIP & AndaDB
 - [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/ModernRelay/omnigraph) Omnigraph: Typed graph database for agent memory. S3-native, Rust, traversal + vector + BM25 in one runtime, Git-style branch/merge.
 - [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/jaylfc/taosmd) taOSmd: Local-first, benchmarked agent memory on an append-only transcript, with a typed temporal knowledge graph where corrected facts supersede old ones via invalidation, plus hybrid vector + BM25 retrieval, tuned for small local models
+- [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/samvallad33/vestige) Vestige: Local-first cognitive memory MCP server for AI coding agents, with a spreading-activation memory graph, hybrid retrieval, FSRS-6 retention with active forgetting, prediction-error gating, and provenance and correction tools, written in Rust on SQLite
 
 ## 📃 Citation
 


### PR DESCRIPTION
Adds Vestige to the Open-source Project section.

Vestige is a local-first cognitive memory MCP server for AI coding agents. It uses a spreading-activation memory graph plus hybrid retrieval, with FSRS-6 retention and active forgetting, prediction-error gating, and provenance and correction tools. Written in Rust on SQLite.

The entry follows the exact format of neighboring items in that section: GitHub badge linking to the repo, then name and a one-line description. Appended after the last existing entry. git diff --check passes with no whitespace errors.