### PR TITLE
Add LWC to open-source projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ This repository provides a comprehensive collection of research papers, benchmar
 - [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/ldclabs/anda-hippocampus) Anda Hippocampus: A native graph-based memory system for autonomous AI agents, featuring bio-inspired sleep-based memory consolidation and powered by KIP & AndaDB
 - [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/ModernRelay/omnigraph) Omnigraph: Typed graph database for agent memory. S3-native, Rust, traversal + vector + BM25 in one runtime, Git-style branch/merge.
 - [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/jaylfc/taosmd) taOSmd: Local-first, benchmarked agent memory on an append-only transcript, with a typed temporal knowledge graph where corrected facts supersede old ones via invalidation, plus hybrid vector + BM25 retrieval, tuned for small local models
+- [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/JanYork/llm-wiki-cli) LWC: Agent-driven proactive memory CLI with source-grounded Wiki memory, a physical document graph, and a separate CodeGraph index for project structure
 
 ## 📃 Citation
 
@@ -350,5 +351,4 @@ This repository provides a comprehensive collection of research papers, benchmar
   year={2026}
 }
 ```
-
 


### PR DESCRIPTION
## Summary

Add LWC to the open-source project list.

LWC is an agent-driven proactive memory CLI. Its graph-based capabilities include a physical Wiki document graph for knowledge relationships and a separate CodeGraph index for current project structure, while preserving source-grounded durable memory across sessions.

## Validation

- [x] The project is not already listed
- [x] The GitHub link returns HTTP 200
- [x] `git diff --check`
